### PR TITLE
Fix for failing Log namespaces filter

### DIFF
--- a/cutelog/logger_tab.py
+++ b/cutelog/logger_tab.py
@@ -308,7 +308,10 @@ class RecordFilter(QSortFilterProxyModel):
                         result = True
                     if path:
                         name = record.name
-                        if name == path:
+                        # name is None for record added by method add_conn_closed_record(). 
+                        if name is None:
+                            result = False
+                        elif name == path:
                             result = True
                         elif not self.selection_includes_children and name == path:
                             result = True


### PR DESCRIPTION
Fix for failing log Namespace filter. It was throwing up error `AttributeError: 'NoneType' object has no attribute 'startswith'.` Added check for 'None' type for record 'name'.
We could also fix in method `add_conn_closed_record()` by adding some unique 'name' key. Because this was adding record without 'name' key.