### PR TITLE
Add config option to disable use system proxy

### DIFF
--- a/cutelog/config.py
+++ b/cutelog/config.py
@@ -72,6 +72,7 @@ OPTION_SPEC = (
     ('single_tab_mode_default',      bool, False),
     ('extra_mode_default',           bool, False),
     ('default_serialization_format', str,  'pickle'),
+    ('use_system_proxy',             bool, False),
 
     # Advanced
     ('console_logging_level',        int,   30),

--- a/cutelog/listener.py
+++ b/cutelog/listener.py
@@ -4,7 +4,7 @@ import struct
 import time
 
 from qtpy.QtCore import QThread, Signal
-from qtpy.QtNetwork import QHostAddress, QTcpServer, QTcpSocket
+from qtpy.QtNetwork import QHostAddress, QTcpServer, QTcpSocket, QNetworkProxyFactory
 
 from .config import CONFIG, MSGPACK_SUPPORT, CBOR_SUPPORT
 from .logger_tab import LogRecord
@@ -27,6 +27,8 @@ class LogServer(QTcpServer):
         self.conn_count = 0
 
         self.threads = []
+        QNetworkProxyFactory.setUseSystemConfiguration(CONFIG['use_system_proxy'])
+
 
     def start(self):
         self.log.info('Starting the server')

--- a/cutelog/resources/ui/settings_dialog.ui
+++ b/cutelog/resources/ui/settings_dialog.ui
@@ -66,7 +66,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="pageAppearance">
       <layout class="QGridLayout" name="gridLayout_3">
@@ -396,32 +396,6 @@
        <property name="verticalSpacing">
         <number>10</number>
        </property>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_16">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Default serialization format</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="listenHostLine">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="placeholderText">
-          <string>0.0.0.0</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label_13">
          <property name="sizePolicy">
@@ -448,8 +422,8 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QLineEdit" name="listenPortLine">
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="listenHostLine">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -457,47 +431,7 @@
           </sizepolicy>
          </property>
          <property name="placeholderText">
-          <string>19996</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0" colspan="2">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_15">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Extra mode by default</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QCheckBox" name="singleTabCheckBox">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QCheckBox" name="extraModeCheckBox">
-         <property name="text">
-          <string/>
+          <string>0.0.0.0</string>
          </property>
         </widget>
        </item>
@@ -521,6 +455,32 @@
          </item>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="listenPortLine">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="placeholderText">
+          <string>19996</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_16">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Default serialization format</string>
+         </property>
+        </widget>
+       </item>
        <item row="4" column="0">
         <widget class="QLabel" name="label_14">
          <property name="sizePolicy">
@@ -534,10 +494,70 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="singleTabCheckBox">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="0" colspan="2">
         <widget class="Line" name="line">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_18">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Use system proxy</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_15">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Extra mode by default</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="extraModeCheckBox">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="6" column="1">
+        <widget class="QCheckBox" name="useSystemProxyCheckBox">
+         <property name="text">
+          <string/>
          </property>
         </widget>
        </item>

--- a/cutelog/settings_dialog.py
+++ b/cutelog/settings_dialog.py
@@ -62,6 +62,7 @@ class SettingsDialog(QDialog):
         self.listenPortLine.setText(str(CONFIG['listen_port']))
         self.singleTabCheckBox.setChecked(CONFIG['single_tab_mode_default'])
         self.extraModeCheckBox.setChecked(CONFIG['extra_mode_default'])
+        self.useSystemProxyCheckBox.setChecked(CONFIG['use_system_proxy'])
         if MSGPACK_SUPPORT:
             self.serializationFormatCombo.addItem("msgpack")
         if CBOR_SUPPORT:
@@ -105,6 +106,7 @@ class SettingsDialog(QDialog):
         o['single_tab_mode_default'] = self.singleTabCheckBox.isChecked()
         o['extra_mode_default'] = self.extraModeCheckBox.isChecked()
         o['default_serialization_format'] = self.serializationFormatCombo.currentText()
+        o['use_system_proxy'] = self.useSystemProxyCheckBox.isChecked()
 
         # Advanced
         o['benchmark_interval'] = float(self.benchmarkIntervalLine.text())


### PR DESCRIPTION
Issue:

I was using a Clash for Windows proxy when starting up cutelog. The following error occurred each time I restarted the server.
![image](https://user-images.githubusercontent.com/25074163/95541819-dc8a0580-0a26-11eb-9356-b8dfd30b525a.png)

After some googling around, I realized the problem is that `QTcpServer` will try to follow the system proxy (my proxy port is at 7890) by default. Changing the cutelog listening port won't solve the problem.

The behavior can be disabled by setting `QNetworkProxyFactory.setUseSystemConfiguration` to `False`. I added a config option to enable or disable such behavior in the settings dialog as well.
