### PR TITLE
Fixing QT save dialog

### DIFF
--- a/cutelog/main_window.py
+++ b/cutelog/main_window.py
@@ -508,6 +508,7 @@ class MainWindow(QMainWindow):
 
         d = QFileDialog(self)
         d.selectFile(logger.name + '.log')
+        d.setAcceptMode(QFileDialog.AcceptSave)
         d.setFileMode(QFileDialog.AnyFile)
         d.fileSelected.connect(partial(self.save_records, logger))
         d.setWindowTitle('Save records of "{}" tab to...'.format(logger.name))


### PR DESCRIPTION
Save dialog was originally opened as Open dialog. This does not
allow to choose custom file name in GTK3 based environments.
This fix sets this dialog as Save dialog explicitly to resolve
this issue.