### PR TITLE
float type is also valid after deserialize

### DIFF
--- a/cutelog/listener.py
+++ b/cutelog/listener.py
@@ -168,7 +168,7 @@ class LogConnection(QThread):
             try:
                 logDict = self.deserialize(data)
                 for k, v in logDict.items():
-                    if type(v) not in (str, int, type(None)):
+                    if type(v) not in (str, int, float, type(None)):
                         logDict[k] = str(v)
                 record = LogRecord(logDict)
             except Exception:

--- a/cutelog/logger_tab.py
+++ b/cutelog/logger_tab.py
@@ -450,7 +450,9 @@ class DetailTableModel(QAbstractTableModel):
         if index.isValid():
             row, column = index.row(), index.column()
             if role == Qt.DisplayRole:
-                return self.record[row][column]
+                row = self.record[index.row()]
+                data = str(row[column]) if row[column] is not None else row[column]
+                return data
         return None
 
     def clear(self):
@@ -467,8 +469,6 @@ class DetailTableModel(QAbstractTableModel):
         self.reset()
 
     def open_row_popup(self, index):
-        print(index)
-        print(index.row())
         row = self.record[index.row()]
         text = str(row[1]) if row[1] is not None else row[1]
         show_textview_dialog(self.parent(), 'Field "{}"'.format(row[0]), text)


### PR DESCRIPTION
Usecase: default python logging with `SocketHandler`. Used with remote debugging (hence lags between log creation and display).

Problem: Time column is not the time of log creation, but local cutelog reception time.

Without float type considered as valid, `created` dict field becomes string, later to be overwritten completely in `logger_tab.py:155`. This PR fixes this issue.