### PR TITLE
Add an option to not resize rows upon each new log record

### DIFF
--- a/cutelog/config.py
+++ b/cutelog/config.py
@@ -80,6 +80,7 @@ OPTION_SPEC = (
     ('benchmark',                    bool,  False),
     ('benchmark_interval',           float, 0.0005),
     ('light_theme_is_native',        bool,  False),
+    ('resize_row_on_add',            bool,  True),
 
     # NON-SETTINGS OPTIONS:
     # Header
@@ -119,6 +120,7 @@ class Config(QObject):
         self.logger_table_font_size = None
         self.logger_row_height = None
         self.benchmark_interval = None
+        self.resize_row_on_add = True
 
         self.update_attributes()
 
@@ -217,6 +219,7 @@ class Config(QObject):
         self.logger_table_font_size = options.get('logger_table_font_size', self.logger_table_font_size)
         self.logger_row_height = options.get('logger_row_height', self.logger_row_height)
         self.set_logging_level(options.get('console_logging_level', ROOT_LOG.level))
+        self.resize_row_on_add = options.get('resize_row_on_add', self.resize_row_on_add)
 
     def emit_needed_changes(self, new_options):
         new_row_height = new_options.get('logger_row_height')

--- a/cutelog/logger_tab.py
+++ b/cutelog/logger_tab.py
@@ -704,7 +704,11 @@ class LoggerTab(QWidget):
             self.register_logger(record.name)
         self.monitor_count += 1
 
-        self.loggerTable.resizeRowToContents(self.filter_model.rowCount() - 1)
+        if CONFIG.resize_row_on_add:
+            # Not calling this on each record can give a boost of ~7-10% in some cases
+            # .. the only expense is that one may need to manually resize columns.
+            self.loggerTable.resizeRowToContents(self.filter_model.rowCount() - 1)
+
         if self.autoscroll:
             self.loggerTable.scrollToBottom()
 

--- a/cutelog/resources/ui/settings_dialog.ui
+++ b/cutelog/resources/ui/settings_dialog.ui
@@ -614,8 +614,8 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="2">
-        <spacer name="verticalSpacer_4">
+       <item row="5" column="0" colspan="2">
+        <spacer name="verticalSpacer_5">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -656,13 +656,26 @@
        <item row="3" column="0">
         <widget class="QLabel" name="lightThemeNativeLabel">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="text">
           <string>Light theme is native style</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="resizeRowOnAddLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Resize each row based off the latest log record</string>
          </property>
         </widget>
        </item>
@@ -691,6 +704,10 @@
          <property name="text">
           <string/>
          </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="resizeRowOnAdd">
         </widget>
        </item>
       </layout>

--- a/cutelog/settings_dialog.py
+++ b/cutelog/settings_dialog.py
@@ -85,6 +85,7 @@ class SettingsDialog(QDialog):
         self.benchmarkIntervalLine.setValidator(QDoubleValidator(0, 1000, 9, self))
         self.benchmarkIntervalLine.setText(str(CONFIG['benchmark_interval']))
         self.lightThemeNativeCheckBox.setChecked(CONFIG['light_theme_is_native'])
+        self.resizeRowOnAdd.setChecked(CONFIG['resize_row_on_add'])
         self.server_restart_needed = False
 
     def save_to_config(self):
@@ -120,6 +121,7 @@ class SettingsDialog(QDialog):
         o['benchmark_interval'] = float(self.benchmarkIntervalLine.text())
         o['benchmark'] = self.benchmarkCheckBox.isChecked()
         o['light_theme_is_native'] = self.lightThemeNativeCheckBox.isChecked()
+        o['resize_row_on_add'] = self.resizeRowOnAdd.isChecked()
         CONFIG.update_options(o)
 
     def accept(self):


### PR DESCRIPTION
This gives me a ~7..10% performance bump without really much issue.

Default behavior matches what it was before