### PR TITLE
Scroll to selected item on filter invalidation

### DIFF
--- a/cutelog/logger_tab.py
+++ b/cutelog/logger_tab.py
@@ -3,10 +3,10 @@ from datetime import datetime
 from functools import partial
 
 from qtpy.QtCore import (QAbstractItemModel, QAbstractTableModel, QEvent, QItemSelectionModel,
-                         QModelIndex, QSize, QSortFilterProxyModel, Qt)
+                         QModelIndex, QSize, QSortFilterProxyModel, QTimer, Qt)
 from qtpy.QtGui import QBrush, QColor, QFont
 from qtpy.QtWidgets import (QCheckBox, QHBoxLayout, QMenu, QShortcut, QStyle,
-                            QTableWidgetItem, QWidget)
+                            QTableWidgetItem, QWidget, QAbstractItemView)
 
 from .config import CONFIG, Exc_Indication
 from .level_edit_dialog import LevelEditDialog
@@ -1040,7 +1040,15 @@ class LoggerTab(QWidget):
         # resizeRowsToContents is very slow, so it's best to try to do it only when necessary
         if resize_rows and (self.extra_mode or self.word_wrap):
             self.loggerTable.resizeRowsToContents()
-        if self.autoscroll:
+        selected = self.loggerTable.selectionModel().currentIndex()
+        if selected.row() > 0: # -1 if nothing selected
+            # scrollTo needs to be called twice, once immediately
+            # and once with some minimal delay. Not sure why
+            def scroll_to_selected():
+                self.loggerTable.scrollTo(selected, QAbstractItemView.PositionAtCenter)
+            scroll_to_selected()
+            QTimer.singleShot(0, scroll_to_selected)
+        elif self.autoscroll:
             self.loggerTable.scrollToBottom()
 
     def onScroll(self, pos):


### PR DESCRIPTION
First of all, thank you for a nice project! A friend of mine uses it, but has issue with the selected item not being kept in the window when filters are changed, exactly as described in #19.

With this fix now the selected item is kept in focus when the filter is changed. If no item is selected, the behavior is identical to the original version.